### PR TITLE
feat(scheme): supporting missing normal values

### DIFF
--- a/src/maflib/column_types.py
+++ b/src/maflib/column_types.py
@@ -554,6 +554,12 @@ class UUIDColumn(MafCustomColumnRecord):
             return None
 
 
+class NullableUUIDColumn(NullableEmptyStringIsNone, UUIDColumn):
+    """A column that represents a UUID.  An empty string is allowed if no 
+    UUID is given."""
+    pass
+
+
 class FeatureType(EnumColumn):
     """A column that represents the 'Feature_Type' MAF column"""
     @classmethod

--- a/src/maflib/resources/gdc-1.0.0.json
+++ b/src/maflib/resources/gdc-1.0.0.json
@@ -19,7 +19,7 @@
 		[ "dbSNP_RS", "SequenceOfStrings" ],
 		[ "dbSNP_Val_Status", "SequenceOfStrings" ],
 		[ "Tumor_Sample_Barcode", "StringColumn" ],
-		[ "Matched_Norm_Sample_Barcode", "StringColumn" ],
+		[ "Matched_Norm_Sample_Barcode", "NullableStringColumn" ],
 		[ "Match_Norm_Seq_Allele1", "NullableDnaString" ],
 		[ "Match_Norm_Seq_Allele2", "NullableDnaString" ],
 		[ "Tumor_Validation_Allele1", "NullableDnaString" ],
@@ -36,7 +36,7 @@
 		[ "BAM_File", "NullableStringColumn" ],
 		[ "Sequencer", "SequenceOfSequencers" ],
 		[ "Tumor_Sample_UUID", "UUIDColumn" ],
-		[ "Matched_Norm_Sample_UUID" , "UUIDColumn" ]
+		[ "Matched_Norm_Sample_UUID" , "NullableUUIDColumn" ]
 	],
 	"filtered" : "None"
 }

--- a/src/maflib/resources/gdc-1.0.1-protected.json
+++ b/src/maflib/resources/gdc-1.0.1-protected.json
@@ -83,7 +83,7 @@
             [ "CONTEXT", "StringColumn" ],
             [ "src_vcf_id", "UUIDColumn" ],
             [ "tumor_bam_uuid", "UUIDColumn" ],
-            [ "normal_bam_uuid", "UUIDColumn" ],
+            [ "normal_bam_uuid", "NullableUUIDColumn" ],
             [ "case_id", "UUIDColumn" ],
             [ "GDC_FILTER", "SequenceOfStrings" ],
             [ "COSMIC", "SequenceOfStrings" ],
@@ -94,7 +94,7 @@
             [ "vcf_info", "NullableStringColumn" ],
             [ "vcf_format", "StringColumn" ],
             [ "vcf_tumor_gt", "StringColumn" ],
-            [ "vcf_normal_gt", "StringColumn" ]
+            [ "vcf_normal_gt", "NullableStringColumn" ]
 	],
 	"filtered" : "None"
 }

--- a/src/maflib/tests/test_column_types.py
+++ b/src/maflib/tests/test_column_types.py
@@ -426,6 +426,10 @@ class TestUUIDColumn(TestCase):
         id = UUID('12345678-1234-5678-1234-567812345678')
         self.is_column_is_valid(UUIDColumn.build("key", str(id)), id)
 
+        # Test the nullable version
+        self.is_column_is_valid(NullableUUIDColumn.build("key", str(id)), id, [None])
+        self.is_column_is_valid(NullableUUIDColumn.build("key", "", id), None, [None])
+
     def test_invalid(self):
         id = UUID('12345678-1234-5678-1234-567812345678')
         self.is_column_invalid(UUIDColumn.build("key", str(id)), "Foo", "was not a UUID")
@@ -437,6 +441,8 @@ class TestUUIDColumn(TestCase):
         with self.assertRaises(ValueError):
             UUIDColumn.build("key", "blah")
 
+        with self.assertRaises(ValueError):
+            UUIDColumn.build("key", "")
 
 class TestTranscriptStrand(TestCase):
     def test_valid(self):


### PR DESCRIPTION
In some cases, MAFs may be given with only a tumor and
no matched normal.  Updates included to support missing
values for the matched normal columns.

