### PR TITLE
fix(featuretype): feature type can be null

### DIFF
--- a/src/maflib/column_types.py
+++ b/src/maflib/column_types.py
@@ -559,8 +559,9 @@ class NullableUUIDColumn(NullableEmptyStringIsNone, UUIDColumn):
     pass
 
 
-class FeatureType(EnumColumn):
-    """A column that represents the 'Feature_Type' MAF column"""
+class FeatureType(NullableEmptyStringIsNone, EnumColumn):
+    """A column that represents the 'Feature_Type' MAF column, with the empty
+    string treated as a null value."""
     @classmethod
     def __enum_class__(cls):
         return FeatureTypeEnum

--- a/src/maflib/column_values.py
+++ b/src/maflib/column_values.py
@@ -129,7 +129,6 @@ class SequencerEnum(MafEnum):
 @unique
 class FeatureTypeEnum(MafEnum):
     """Enumeration for the MAF 'Feature_Type' column value"""
-    Blank = ""
     Transcript = "Transcript"
     RegulatoryFeature = "RegulatoryFeature"
     MotifFeature = "MotifFeature"


### PR DESCRIPTION
Allow the feature type to be null.

@kmhernan this should make this column consistent with `VerificationStatus` and `class ValidationStatus` when wanting its value to be null.