### PR TITLE
feat(scheme): column description in scheme

### DIFF
--- a/src/maflib/column_types.py
+++ b/src/maflib/column_types.py
@@ -25,8 +25,7 @@ def get_column_types():
     def predicate(obj):
         """A predicate to get all classes that are subclasses of
         MafColumnRecord"""
-        return inspect.isclass(obj) and issubclass(obj,
-                                                   MafColumnRecord)
+        return inspect.isclass(obj) and issubclass(obj, MafColumnRecord)
         # Get all available column types
 
     return inspect.getmembers(sys.modules["maflib.column_types"],

--- a/src/maflib/record.py
+++ b/src/maflib/record.py
@@ -234,6 +234,7 @@ class MafRecord(MutableMapping):
             self.validation_errors.append(error)
 
         # Validate the # of columns against the given scheme
+
         if scheme and len(scheme) != len(self):
             add_errors(MafValidationError(
                 MafValidationErrorType.RECORD_MISMATCH_NUMBER_OF_COLUMNS,
@@ -343,8 +344,8 @@ class MafRecord(MutableMapping):
                                              column_index=column_index)
                 else:
                     try:
-                        scheme_column_class = scheme.column_class(
-                            name=column_name)
+                        scheme_column_class = \
+                            scheme.column_class(name=column_name)
                         column = scheme_column_class.build(
                             name=column_name,
                             value=column_value,

--- a/src/maflib/tests/test_schemes.py
+++ b/src/maflib/tests/test_schemes.py
@@ -9,6 +9,11 @@ from maflib.tests.testutils import GdcV1_0_0_BasicScheme, \
 
 class TestMafScheme(unittest.TestCase):
     class TestScheme(MafScheme):
+        _Columns = [
+            MafHeaderVersionRecord("test-scheme"),
+            MafHeaderRecord("key1", "value1")
+        ]
+
         @classmethod
         def version(cls):
             return "test-scheme"
@@ -19,11 +24,15 @@ class TestMafScheme(unittest.TestCase):
 
         @classmethod
         def __column_dict__(cls):
-            columns = [
-                MafHeaderVersionRecord(TestMafScheme.TestScheme.version()),
-                MafHeaderRecord("key1", "value1")
-            ]
-            return OrderedDict([(column.key, column.__class__) for column in columns])
+            return OrderedDict([(column.key, column.__class__) for column in
+                                TestMafScheme.TestScheme._Columns])
+
+        @classmethod
+        def __column_desc__(cls):
+            return OrderedDict([(column.key, str(column.__class__))
+                                for column in
+                                TestMafScheme.TestScheme._Columns])
+
 
     def test_version(self):
         self.assertEqual(TestMafScheme.TestScheme().version(), "test-scheme")
@@ -41,9 +50,22 @@ class TestMafScheme(unittest.TestCase):
         self.assertEqual(scheme.column_index("key1"), 1)
         self.assertEqual(scheme.column_index("key2"), None)
 
+    def test_column_description(self):
+        scheme = TestMafScheme.TestScheme()
+        self.assertEqual(scheme.column_description(MafHeader.VersionKey),
+                         str(MafHeaderVersionRecord))
+        self.assertEqual(scheme.column_description("key1"),
+                         str(MafHeaderRecord))
+        self.assertEqual(scheme.column_description("key2"), None)
+
     def test_column_names(self):
         scheme = TestMafScheme.TestScheme()
         self.assertListEqual(scheme.column_names(), [MafHeader.VersionKey, "key1"])
+
+    def test_column_descriptions(self):
+        scheme = TestMafScheme.TestScheme()
+        self.assertListEqual(scheme.column_descriptions(),
+                             [MafHeader.VersionKey, "key1"])
 
     def test_str(self):
         scheme = TestMafScheme.TestScheme()


### PR DESCRIPTION
Store the column description in the scheme.

@kmhernan this was a little harder than I thought, since I had to do some refactoring in `scheme_factory` to store multiple pieces of information for a column (name, class, description), versus previously I could simply have a dictionary from name to class.  I have updated the tests, but not the pre-configured scheme JSON files.