### PR TITLE
feat(column): add string column tests

### DIFF
--- a/src/maflib/column_types.py
+++ b/src/maflib/column_types.py
@@ -59,12 +59,20 @@ class RequireNullValue(MafColumnRecord):
         return "'%s' was not a null value" % str(self.value)
 
 
-class NullableStringColumn(NullableEmptyStringIsNone, MafCustomColumnRecord):
-    """ A column where the value must be a string, with its null value being
-    an empty string"""
+class _BuildStringColumn(object):
+    """Mix this in to require a string as the value"""
     @classmethod
     def __build__(cls, value):
+        if not isinstance(value, basestring):
+            raise ValueError("'%s' was not a string (was %s)"
+                             % (str(value), str(value.__class__)))
         return str(value)
+
+
+class NullableStringColumn(NullableEmptyStringIsNone, _BuildStringColumn,
+                           MafCustomColumnRecord):
+    """ A column where the value must be a string, with its null value being
+    an empty string"""
 
     def __validate__(self):
         if not isinstance(self.value, str):
@@ -316,16 +324,12 @@ class SequenceOfIntegers(NullableEmptyStringIsEmptyList,
         return IntegerColumn
 
 
-class NullableDnaString(MafCustomColumnRecord):
+class NullableDnaString(_BuildStringColumn, MafCustomColumnRecord):
     """A column that represents a string of DNA bases, or an empty string
     treated as the null value"""
     @classmethod
     def __nullable_dict__(cls):
         return {"": None}
-
-    @classmethod
-    def __build__(cls, value):
-        return str(value)
 
     def __validate__(self):
         if not isinstance(self.value, str):
@@ -344,10 +348,6 @@ class DnaString(NullableDnaString):
     @classmethod
     def __nullable_dict__(cls):
         return None
-
-    @classmethod
-    def __build__(cls, value):
-        return str(value)
 
     def __validate__(self):
         msg = super(DnaString, self).__validate__()

--- a/src/maflib/tests/test_column_types.py
+++ b/src/maflib/tests/test_column_types.py
@@ -41,10 +41,13 @@ class TestRequireNullValue(TestCase):
 class TestNullableStringColumn(TestCase):
     def test_valid(self):
         self.is_column_is_valid(NullableStringColumn.build("key", "Foo"), "Foo", [None])
+        self.is_column_is_valid(NullableStringColumn.build("key", ""), None,
+                                [None])
 
     def test_invalid(self):
         self.is_column_invalid(NullableStringColumn.build("key", "Foo"), 2, "'2' was not a string")
-
+        self.is_column_invalid(StringColumn.build("key", "Foo"), None,
+                                   "'None' was not a string")
 
 class TestStringColumn(TestCase):
     def test_valid(self):
@@ -53,6 +56,8 @@ class TestStringColumn(TestCase):
     def test_invalid(self):
         self.is_column_invalid(StringColumn.build("key", "Foo"), 2, "'2' was not a string")
         self.is_column_invalid(StringColumn.build("key", ""), "", StringColumn.EmptyStringMessage)
+        self.is_column_invalid(StringColumn.build("key", "Foo"), None,
+                               "'None' was not a string")
 
 
 class TestStringIntegerOrFloatColumn(TestCase):


### PR DESCRIPTION
Adding string column tests for input values.

@kmhernan a column of type `StringColumn` should always have a string passed in, so passing in `None` is not allowed (tests added), and an empty string isn't allowed either.  A column of type `NullableStringColumn` allows for an empty string, but still not `None`.  Hopefully this clarifies the question you had about passing in `None` to string columns.